### PR TITLE
Single file resources

### DIFF
--- a/TAC_COM/Services/UriService.cs
+++ b/TAC_COM/Services/UriService.cs
@@ -26,18 +26,18 @@ namespace TAC_COM.Services
         public Uri GetThemeUri(string themeName)
         {
             string relativePath = $"{string.Join("/", themeDirectoryFolders)}/Theme{themeName}.xaml";
-            return new Uri($"pack://application:,,,/{relativePath}", UriKind.Absolute);
+            return new Uri(relativePath, UriKind.Relative);
         }
 
         public Uri GetIconUri(string iconName)
         {
             string relativePath = $"{string.Join("/", iconDirectoryFolders)}/Icon-{iconName}.ico";
-            return new Uri($"pack://application:,,,/{relativePath}", UriKind.Absolute);
+            return new Uri(relativePath, UriKind.Relative);
         }
 
         public Uri GetResourcesUri()
         {
-            return new Uri("pack://application:,,,/Resources.xaml");
+            return new Uri("/Resources.xaml", UriKind.Relative);
         }
     }
 }

--- a/TAC_COM/TAC_COM.csproj
+++ b/TAC_COM/TAC_COM.csproj
@@ -34,6 +34,14 @@
     <None Remove="Static\SFX\Noise\NoiseSSC.wav" />
   </ItemGroup>
 
+	<ItemGroup>
+	  <Page Remove="Themes\ThemeGMS.xaml" />
+	  <Page Remove="Themes\ThemeHA.xaml" />
+	  <Page Remove="Themes\ThemeHORUS.xaml" />
+	  <Page Remove="Themes\ThemeIPSN.xaml" />
+	  <Page Remove="Themes\ThemeSSC.xaml" />
+	</ItemGroup>
+
   <ItemGroup>
     <Content Include="Static\Icons\enabled.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -113,6 +121,14 @@
     <PackageReference Include="Dapplo.Windows.Input" Version="1.0.28" />
     <PackageReference Include="NWaves" Version="0.9.6" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Resource Include="Themes\ThemeGMS.xaml" />
+    <Resource Include="Themes\ThemeHA.xaml" />
+    <Resource Include="Themes\ThemeHORUS.xaml" />
+    <Resource Include="Themes\ThemeIPSN.xaml" />
+    <Resource Include="Themes\ThemeSSC.xaml" />
   </ItemGroup>
 
 </Project>

--- a/Tests/UnitTests/ServiceTests/UriServiceTests.cs
+++ b/Tests/UnitTests/ServiceTests/UriServiceTests.cs
@@ -33,7 +33,7 @@ namespace Tests.UnitTests.ServiceTests
         {
 
             string expectedRelativePath = "Folder1/Folder2/ThemeTEST.xaml";
-            Uri expectedUri = new($"pack://application:,,,/{expectedRelativePath}", UriKind.Absolute);
+            Uri expectedUri = new(expectedRelativePath, UriKind.Relative);
             Uri resultUri = uriService.GetThemeUri("TEST");
 
             Assert.AreEqual(expectedUri, resultUri);
@@ -46,7 +46,7 @@ namespace Tests.UnitTests.ServiceTests
         public void TestGetIconUri()
         {
             string expectedRelativePath = "FolderA/FolderB/Icon-Test.ico";
-            Uri expectedUri = new($"pack://application:,,,/{expectedRelativePath}", UriKind.Absolute);
+            Uri expectedUri = new(expectedRelativePath, UriKind.Relative);
             Uri resultUri = uriService.GetIconUri("Test");
 
             Assert.AreEqual(expectedUri, resultUri);
@@ -58,7 +58,7 @@ namespace Tests.UnitTests.ServiceTests
         [TestMethod]
         public void TestGetResourcesUri()
         {
-            Uri expectedUri = new($"pack://application:,,,/Resources.xaml", UriKind.Absolute);
+            Uri expectedUri = new("/Resources.xaml", UriKind.Relative);
             Uri resultUri = uriService.GetResourcesUri();
 
             Assert.AreEqual(expectedUri, resultUri);


### PR DESCRIPTION
Updates the UriService to use relative Uri paths. This prevents missing resource errors when publishing as a single file. Updates tests accordingly.