### PR TITLE
Defer UI Update Until Playback Ready

### DIFF
--- a/TAC_COM/Models/AudioManager.cs
+++ b/TAC_COM/Models/AudioManager.cs
@@ -134,6 +134,17 @@ namespace TAC_COM.Models
             }
         }
 
+        private bool playbackReady;
+        public bool PlaybackReady
+        {
+            get => playbackReady;
+            set
+            {
+                playbackReady = value;
+                OnPropertyChanged(nameof(PlaybackReady));
+            }
+        }
+
         private bool bypassState;
 
         /// <inheritdoc/>
@@ -332,10 +343,12 @@ namespace TAC_COM.Models
                     return;
                 }
                 await StartAudioAsync();
+                PlaybackReady = true;
             }
             else
             {
                 await StopAudioAsync();
+                PlaybackReady = false;
             }
         }
 

--- a/TAC_COM/Models/Interfaces/IAudioManager.cs
+++ b/TAC_COM/Models/Interfaces/IAudioManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace TAC_COM.Models.Interfaces
 {
@@ -7,13 +8,19 @@ namespace TAC_COM.Models.Interfaces
     /// as well as any properties that need to be exposed to the view model
     /// layer.
     /// </summary>
-    public interface IAudioManager : IDisposable
+    public interface IAudioManager : INotifyPropertyChanged, IDisposable
     {
         /// <summary>
         /// Gets or sets the value representing the overall state of the
         /// <see cref="IAudioManager"/>.
         /// </summary>
         bool State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value representing whether the 
+        /// <see cref="IAudioManager"/> is ready to start playback.
+        /// </summary>
+        bool PlaybackReady { get; set; }
 
         /// <summary>
         /// Gets or sets the value representing whether the

--- a/TAC_COM/Views/AudioInterfaceView.xaml
+++ b/TAC_COM/Views/AudioInterfaceView.xaml
@@ -42,7 +42,7 @@
                 <ComboBox x:Name="InputSelection" Width="300" 
                           ItemsSource="{Binding AllInputDevices}"
                           SelectedItem="{Binding InputDevice}"
-                          IsEnabled="{Binding IsSelectable}"
+                          IsEnabled="{Binding UIDeviceControlsEnabled}"
                           Text="SELECT INPUT DEVICE" FontFamily="Calibri" FontSize="14"
                           Cursor="Hand"
                           Focusable="False" IsEditable="True" IsReadOnly="True"
@@ -76,7 +76,7 @@
                 <ComboBox x:Name="OutputSelection" Width="300"
                           ItemsSource="{Binding AllOutputDevices}"
                           SelectedItem="{Binding OutputDevice}"
-                          IsEnabled="{Binding IsSelectable}"
+                          IsEnabled="{Binding UIDeviceControlsEnabled}"
                           Text="SELECT VIRTUAL OUTPUT DEVICE" FontFamily="Calibri" FontSize="14"
                           Cursor="Hand"
                           Focusable="False" IsEditable="True" IsReadOnly="True"
@@ -110,7 +110,7 @@
                 <ComboBox x:Name="ProfileSelection" Width="300"
                           ItemsSource="{Binding Profiles}"
                           SelectedItem="{Binding ActiveProfile}"
-                          IsEnabled="{Binding IsSelectable}"
+                          IsEnabled="{Binding UIDeviceControlsEnabled}"
                           Text="SELECT MANUFACTURER" FontFamily="Calibri" FontSize="14"
                           Cursor="Hand"
                           Focusable="False" IsEditable="True" IsReadOnly="True"
@@ -142,7 +142,7 @@
                                 HorizontalAlignment="Center" VerticalAlignment="Center" 
                                 HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                                 Foreground="{DynamicResource {x:Static adonisUi:Brushes.Layer2IntenseHighlightBrush}}" Cursor="Hand"
-                                IsEnabled="{Binding IsSelectable}" Command="{Binding ShowKeybindDialog}" FontSize="10"
+                                IsEnabled="{Binding UIDeviceControlsEnabled}" Command="{Binding ShowKeybindDialog}" FontSize="10"
                                 BorderThickness="0"
                                 adonisExtensions:CursorSpotlightExtension.RelativeSpotlightSize="0"
                                 adonisExtensions:CursorSpotlightExtension.MaxBlurRadius="0">
@@ -223,7 +223,7 @@
                 <ToggleButton HorizontalAlignment="Center" Margin="10" Width="140"
                               Foreground="{DynamicResource {x:Static adonisUi:Brushes.Layer2IntenseHighlightBrush}}" 
                               FontSize="18" FontWeight="ExtraLight"
-                              IsChecked="{Binding BypassState}" IsEnabled="{Binding State}"
+                              IsChecked="{Binding BypassState}" IsEnabled="{Binding UIPTTControlsEnabled}"
                               VerticalAlignment="Center" Cursor="Hand">
                     <ToggleButton.Style>
                         <Style TargetType="ToggleButton">

--- a/Tests/MockModels/MockAudioManager.cs
+++ b/Tests/MockModels/MockAudioManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 using TAC_COM.Models.Interfaces;
 
 namespace Tests.MockModels
@@ -20,6 +21,10 @@ namespace Tests.MockModels
         public ObservableCollection<IMMDeviceWrapper> OutputDevices { get; set; } = [];
         public IProfile? ActiveProfile { get; set; }
         public float InterferenceLevel { get; set; }
+        public bool PlaybackReady { get; set; }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
         public void GetAudioDevices() { }
 
         public void SetInputDevice(IMMDeviceWrapper inputDevice) { }

--- a/Tests/UnitTests/ModelTests/AudioManagerTests.cs
+++ b/Tests/UnitTests/ModelTests/AudioManagerTests.cs
@@ -399,7 +399,7 @@ namespace Tests.UnitTests.ModelTests
 
 
         /// <summary>
-        /// Test method for the <see cref="AudioManager.ResetOutputDevice"/> method,
+        /// Test method for the <see cref="AudioManager.ToggleStateAsync"/> method,
         /// with a test case of <see cref="AudioManager.State"/> = true,
         /// <see cref="AudioManager.InputDevices"/> = null and 
         /// <see cref="AudioManager.OutputDevices"/> = null.
@@ -420,20 +420,21 @@ namespace Tests.UnitTests.ModelTests
             FieldInfo? activeOutputField = typeof(AudioManager).GetField("activeOutputDevice", BindingFlags.NonPublic | BindingFlags.Instance);
             activeOutputField?.SetValue(audioManager, null);
 
+            FieldInfo? inputField = typeof(AudioManager).GetField("input", BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo? micOutputField = typeof(AudioManager).GetField("micOutput", BindingFlags.NonPublic | BindingFlags.Instance);
+
             await audioManager.ToggleStateAsync();
 
             Assert.IsFalse(audioManager.State);
-            FieldInfo? inputField = typeof(AudioManager).GetField("input", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsFalse(audioManager.PlaybackReady);
             var inputValue = inputField?.GetValue(audioManager);
             Assert.IsNull(inputValue);
-
-            FieldInfo? micOutputField = typeof(AudioManager).GetField("micOutput", BindingFlags.NonPublic | BindingFlags.Instance);
             var outputValue = micOutputField?.GetValue(audioManager);
             Assert.IsNull(outputValue);
         }
 
         /// <summary>
-        /// Test method for the <see cref="AudioManager.ResetOutputDevice"/> method,
+        /// Test method for the <see cref="AudioManager.ToggleStateAsync"/> method,
         /// with a test case of <see cref="AudioManager.State"/> = true,
         /// <see cref="AudioManager.InputDevices"/> and 
         /// <see cref="AudioManager.OutputDevices"/> as valid devices.
@@ -502,6 +503,7 @@ namespace Tests.UnitTests.ModelTests
             await audioManager.ToggleStateAsync();
 
             Assert.IsTrue(audioManager.State);
+            Assert.IsTrue(audioManager.PlaybackReady);
 
             mockProfile.Verify(profile => profile.LoadSources(), Times.Once());
 
@@ -525,7 +527,7 @@ namespace Tests.UnitTests.ModelTests
         }
 
         /// <summary>
-        /// Test method for the <see cref="AudioManager.ResetOutputDevice"/> method,
+        /// Test method for the <see cref="AudioManager.ToggleStateAsync"/> method,
         /// with a test case of <see cref="AudioManager.State"/> = false,
         /// <see cref="AudioManager.InputDevices"/> and 
         /// <see cref="AudioManager.OutputDevices"/> as valid devices.
@@ -557,6 +559,8 @@ namespace Tests.UnitTests.ModelTests
 
             mockWasapiOutput.Verify(output => output.Stop(), Times.Once);
             mockWasapiOutput.Verify(output => output.Dispose(), Times.Once);
+
+            Assert.IsFalse(audioManager.PlaybackReady);
         }
 
         /// <summary>

--- a/Tests/UnitTests/ViewModelTests/AudioInterfaceViewModelTests.cs
+++ b/Tests/UnitTests/ViewModelTests/AudioInterfaceViewModelTests.cs
@@ -146,32 +146,32 @@ namespace Tests.UnitTests.ViewModelTests
             mockIconService.Setup(iconService => iconService.SetStandbyIcon()).Verifiable();
             mockIconService.Setup(iconService => iconService.SetEnabledIcon()).Verifiable();
 
-            var mockKeybindManager = new Mock<IKeybindManager>();
-            mockKeybindManager.Setup(keybindManager => keybindManager.TogglePTTKeybindSubscription(true));
-            mockKeybindManager.Setup(keybindManager => keybindManager.TogglePTTKeybindSubscription(false));
-
             testViewModel.IconService = mockIconService.Object;
-            testViewModel.KeybindManager = mockKeybindManager.Object;
 
             Utils.TestPropertyChange(testViewModel, nameof(testViewModel.State), true);
-            Assert.IsFalse(testViewModel.IsSelectable);
             mockIconService.Verify(iconService => iconService.SetEnabledIcon(), Times.Once);
-            mockKeybindManager.Verify(keybindManager => keybindManager.TogglePTTKeybindSubscription(true), Times.Once);
 
             Utils.TestPropertyChange(testViewModel, nameof(testViewModel.State), false);
-            Assert.IsTrue(testViewModel.IsSelectable);
             Assert.IsFalse(testViewModel.BypassState);
             mockIconService.Verify(iconService => iconService.SetStandbyIcon(), Times.Once);
-            mockKeybindManager.Verify(keybindManager => keybindManager.TogglePTTKeybindSubscription(false), Times.Once);
         }
 
         /// <summary>
-        /// Test method for the <see cref="AudioInterfaceViewModel.IsSelectable"/> property.
+        /// Test method for the <see cref="AudioInterfaceViewModel.UIDeviceControlsEnabled"/> property.
         /// </summary>
         [TestMethod]
-        public void TestIsSelectableProperty()
+        public void TestUIDeviceControlsEnabledProperty()
         {
-            Utils.TestPropertyChange(testViewModel, nameof(testViewModel.IsSelectable), !testViewModel.IsSelectable);
+            Utils.TestPropertyChange(testViewModel, nameof(testViewModel.UIDeviceControlsEnabled), !testViewModel.UIDeviceControlsEnabled);
+        }
+
+        /// <summary>
+        /// Test method for the <see cref="AudioInterfaceViewModel.UIPTTControlsEnabled"/> property.
+        /// </summary>
+        [TestMethod]
+        public void TestUIPTTControlsEnabledProperty()
+        {
+            Utils.TestPropertyChange(testViewModel, nameof(testViewModel.UIPTTControlsEnabled), !testViewModel.UIPTTControlsEnabled);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace Tests.UnitTests.ViewModelTests
             string testKeybindNameValue = "Shift + V";
 
             Utils.TestPropertyChange(testViewModel, nameof(testViewModel.KeybindName), testKeybindNameValue);
-            Assert.IsTrue(testViewModel.KeybindName == "[ Shift + V ]");
+            Assert.AreEqual("[ Shift + V ]", testViewModel.KeybindName);
         }
 
         /// <summary>

--- a/Tests/UnitTests/ViewModelTests/AudioInterfaceViewModelTests.cs
+++ b/Tests/UnitTests/ViewModelTests/AudioInterfaceViewModelTests.cs
@@ -581,6 +581,44 @@ namespace Tests.UnitTests.ViewModelTests
         }
 
         /// <summary>
+        /// Test method for the <see cref="AudioInterfaceViewModel.KeybindManager_PropertyChange"/> event handler.
+        /// </summary>
+        [TestMethod]
+        public void TestKeybindManager_PropertyChanged()
+        {
+            var mockKeybindManager = new Mock<IKeybindManager>();
+            mockKeybindManager.SetupAllProperties();
+            
+            var propertyChangeMethod = typeof(AudioInterfaceViewModel)
+                .GetMethod("KeybindManager_PropertyChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            void handler(object? sender, PropertyChangedEventArgs args)
+            {
+                propertyChangeMethod?.Invoke(testViewModel, [sender, args]);
+            }
+
+            mockKeybindManager.Object.PropertyChanged += handler;
+            testViewModel.KeybindManager = mockKeybindManager.Object;
+
+            mockKeybindManager.Object.ToggleState = true;
+            mockKeybindManager.Raise(m => m.PropertyChanged += null, new PropertyChangedEventArgs("ToggleState"));
+
+            Assert.IsTrue(testViewModel.BypassState);
+
+            mockKeybindManager.Object.PTTKey
+                = new Keybind(Dapplo.Windows.Input.Enums.VirtualKeyCode.KeyV,
+                    false,
+                    true,
+                    false,
+                    false,
+                    false);
+
+            mockKeybindManager.Raise(m => m.PropertyChanged += null, new PropertyChangedEventArgs("PTTKey"));
+
+            Assert.AreEqual("[ CTRL + V ]", testViewModel.KeybindName);
+        }
+
+        /// <summary>
         /// Test method for the <see cref="AudioInterfaceViewModel.ShowKeybindDialog"/> method.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
Defers the updating of the UI ptt key until playback resources are fully loaded. Whilst this causes a slight delay when clicking the "Enable" button before the ptt key becomes interactable, this prevents any ptt keybinds pressed prior to playback being ready from registering but not doing anything.

Adds several tests to ensure the new PlaybackReady property and event handlers work correctly.