### PR TITLE
Implement CancellationToken

### DIFF
--- a/TAC_COM/Models/Interfaces/IWasapiCaptureWrapper.cs
+++ b/TAC_COM/Models/Interfaces/IWasapiCaptureWrapper.cs
@@ -40,7 +40,7 @@ namespace TAC_COM.Models.Interfaces
         /// Method to initialise the <see cref="WasapiCapture"/>, ready
         /// for recording.
         /// </summary>
-        void Initialize();
+        void Initialise();
 
         /// <summary>
         /// Method to start the <see cref="WasapiCapture"/> recording.

--- a/TAC_COM/Models/Interfaces/IWasapiOutWrapper.cs
+++ b/TAC_COM/Models/Interfaces/IWasapiOutWrapper.cs
@@ -6,7 +6,7 @@ namespace TAC_COM.Models.Interfaces
 {
     /// <summary>
     /// Interface representing the wrapper for a
-    /// <see cref="CSCore.SoundOut.WasapiOut"/>.
+    /// <see cref="WasapiOut"/>.
     /// </summary>
     public interface IWasapiOutWrapper
     {

--- a/TAC_COM/Models/WasapiCaptureWrapper.cs
+++ b/TAC_COM/Models/WasapiCaptureWrapper.cs
@@ -8,8 +8,10 @@ namespace TAC_COM.Models
     /// Wrapper class for the <see cref="WasapiCapture"/>, to facilitate
     /// easier testing.
     /// </summary>
-    public class WasapiCaptureWrapper : IWasapiCaptureWrapper
+    public class WasapiCaptureWrapper(CancellationToken token) : IWasapiCaptureWrapper
     {
+        private readonly CancellationToken cancellationToken = token;
+
         private WasapiCapture wasapiCapture = new(false, AudioClientShareMode.Shared, 5);
         public WasapiCapture WasapiCapture
         {
@@ -41,15 +43,34 @@ namespace TAC_COM.Models
             remove => wasapiCapture.Stopped -= value;
         }
 
-        public void Dispose() => wasapiCapture.Dispose();
+        public void Dispose()
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                wasapiCapture.Dispose();
+            };
+        }
 
-        public void Initialize() => wasapiCapture.Initialize();
+        public void Initialise()
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                wasapiCapture.Initialize();
+            }
+        }
 
-        public void Start() => wasapiCapture.Start();
+        public void Start()
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                wasapiCapture.Start();
+            }
+        }
 
         public void Stop()
         {
-            if (wasapiCapture.RecordingState != RecordingState.Stopped)
+            if (wasapiCapture.RecordingState != RecordingState.Stopped
+                && !cancellationToken.IsCancellationRequested)
             {
                 wasapiCapture.Stop();
             }

--- a/TAC_COM/Models/WasapiOutWrapper.cs
+++ b/TAC_COM/Models/WasapiOutWrapper.cs
@@ -6,11 +6,13 @@ using TAC_COM.Models.Interfaces;
 namespace TAC_COM.Models
 {
     /// <summary>
-    /// Wrapper class for the <see cref="CSCore.SoundOut.WasapiOut"/>,
+    /// Wrapper class for the <see cref="WasapiOut"/>,
     /// to faciliate easier testing.
     /// </summary>
-    public class WasapiOutWrapper : IWasapiOutWrapper
+    public class WasapiOutWrapper(CancellationToken token) : IWasapiOutWrapper
     {
+        private readonly CancellationToken cancellationToken = token;
+
         private readonly WasapiOut wasapiOut = new() { Latency = 5 };
         public MMDevice Device
         {
@@ -37,17 +39,35 @@ namespace TAC_COM.Models
         }
 
 
-        public void Dispose() => wasapiOut.Dispose();
+        public void Dispose()
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                wasapiOut.Dispose();
+            }
+        }
 
 
-        public void Initialise(IWaveSource? source) => wasapiOut.Initialize(source);
+        public void Initialise(IWaveSource? source) 
+        { 
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                wasapiOut.Initialize(source);
+            }
+        }
 
-
-        public void Play() => wasapiOut.Play();
+        public void Play() 
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                wasapiOut.Play();
+            }
+        }
 
         public void Stop()
         {
-            if (wasapiOut.PlaybackState != PlaybackState.Stopped)
+            if (wasapiOut.PlaybackState != PlaybackState.Stopped
+                && !cancellationToken.IsCancellationRequested)
             {
                 wasapiOut.Stop();
             }

--- a/TAC_COM/Services/Interfaces/IWasapiService.cs
+++ b/TAC_COM/Services/Interfaces/IWasapiService.cs
@@ -12,13 +12,15 @@ namespace TAC_COM.Services.Interfaces
         /// <summary>
         /// Method to create a new <see cref="IWasapiCaptureWrapper"/>.
         /// </summary>
-        /// <returns> The new <see cref="IWasapiCaptureWrapper"/>.</returns>
-        IWasapiCaptureWrapper CreateWasapiCapture();
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> from the <see cref="IAudioManager"/>.</param>
+        /// <returns> The created <see cref="IWasapiCaptureWrapper"/>.</returns>
+        IWasapiCaptureWrapper CreateWasapiCapture(CancellationToken cancellationToken);
 
         /// <summary>
         /// Method to create a new <see cref="IWasapiOutWrapper"/>.
         /// </summary>
-        /// <returns> The new <see cref="IWasapiOutWrapper"/>.</returns>
-        IWasapiOutWrapper CreateWasapiOut();
+        /// <param name="cancellationToken"> The <see cref="CancellationToken"/> from the <see cref="IAudioManager"/>.</param>
+        /// <returns> The created <see cref="IWasapiOutWrapper"/>.</returns>
+        IWasapiOutWrapper CreateWasapiOut(CancellationToken cancellationToken);
     }
 }

--- a/TAC_COM/Services/WasapiService.cs
+++ b/TAC_COM/Services/WasapiService.cs
@@ -1,4 +1,5 @@
-﻿using TAC_COM.Models;
+﻿using System.Threading;
+using TAC_COM.Models;
 using TAC_COM.Models.Interfaces;
 using TAC_COM.Services.Interfaces;
 
@@ -10,14 +11,14 @@ namespace TAC_COM.Services
     /// </summary>
     public class WasapiService : IWasapiService
     {
-        public IWasapiCaptureWrapper CreateWasapiCapture()
+        public IWasapiCaptureWrapper CreateWasapiCapture(CancellationToken cancellationToken)
         {
-            return new WasapiCaptureWrapper();
+            return new WasapiCaptureWrapper(cancellationToken);
         }
 
-        public IWasapiOutWrapper CreateWasapiOut()
+        public IWasapiOutWrapper CreateWasapiOut(CancellationToken cancellationToken)
         {
-            return new WasapiOutWrapper();
+            return new WasapiOutWrapper(cancellationToken);
         }
     }
 }

--- a/Tests/UnitTests/ModelTests/AudioManagerTests.cs
+++ b/Tests/UnitTests/ModelTests/AudioManagerTests.cs
@@ -463,7 +463,7 @@ namespace Tests.UnitTests.ModelTests
                 .SetupAdd(input => input.Stopped += It.IsAny<EventHandler<RecordingStoppedEventArgs>>())
                 .Callback<EventHandler<RecordingStoppedEventArgs>>(inputStoppedHandlers.Add);
 
-            mockWasapiInput.Setup(input => input.Initialize()).Verifiable();
+            mockWasapiInput.Setup(input => input.Initialise()).Verifiable();
             mockWasapiInput.Setup(input => input.Start()).Verifiable();
 
             var mockWasapiOut = new Mock<IWasapiOutWrapper>();
@@ -475,8 +475,8 @@ namespace Tests.UnitTests.ModelTests
 
             mockWasapiOut.Setup(output => output.Play()).Verifiable();
 
-            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiCapture()).Returns(mockWasapiInput.Object);
-            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiOut()).Returns(mockWasapiOut.Object);
+            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiCapture(It.IsAny<CancellationToken>())).Returns(mockWasapiInput.Object);
+            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiOut(It.IsAny<CancellationToken>())).Returns(mockWasapiOut.Object);
 
             var mockAudioProcessor = new Mock<IAudioProcessor>();
             var mockWaveSource = new Mock<IWaveSource>();
@@ -515,7 +515,7 @@ namespace Tests.UnitTests.ModelTests
             var outputValue = micOutputField?.GetValue(audioManager);
             Assert.AreEqual(outputValue, mockWasapiOut.Object);
 
-            mockWasapiInput.Verify(input => input.Initialize(), Times.Once());
+            mockWasapiInput.Verify(input => input.Initialise(), Times.Once());
             mockWasapiInput.Verify(input => input.Start(), Times.Once());
             mockAudioProcessor.Verify(audioProcessor => audioProcessor.Initialise(mockWasapiInput.Object, mockProfile.Object), Times.Once());
             mockWasapiOut.Verify(output => output.Initialise(mockWaveSource.Object), Times.Once());
@@ -611,8 +611,8 @@ namespace Tests.UnitTests.ModelTests
             var mockWasapiOut = new Mock<IWasapiOutWrapper>();
             mockWasapiOut.Setup(output => output.Play()).Verifiable();
 
-            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiCapture()).Returns(mockWasapiInput.Object);
-            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiOut()).Returns(mockWasapiOut.Object);
+            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiCapture(It.IsAny<CancellationToken>())).Returns(mockWasapiInput.Object);
+            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiOut(It.IsAny<CancellationToken>())).Returns(mockWasapiOut.Object);
 
             var mockAudioProcessor = new Mock<IAudioProcessor>();
             mockAudioProcessor.SetupAllProperties();
@@ -666,8 +666,8 @@ namespace Tests.UnitTests.ModelTests
             var mockWasapiOut = new Mock<IWasapiOutWrapper>();
             mockWasapiOut.Setup(output => output.Play()).Verifiable();
 
-            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiCapture()).Returns(mockWasapiInput.Object);
-            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiOut()).Returns(mockWasapiOut.Object);
+            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiCapture(It.IsAny<CancellationToken>())).Returns(mockWasapiInput.Object);
+            mockWasapiService.Setup(wasapiService => wasapiService.CreateWasapiOut(It.IsAny<CancellationToken>())).Returns(mockWasapiOut.Object);
 
             var mockAudioProcessor = new Mock<IAudioProcessor>();
             mockAudioProcessor.SetupAllProperties();

--- a/Tests/UnitTests/ServiceTests/WasapiServiceTests.cs
+++ b/Tests/UnitTests/ServiceTests/WasapiServiceTests.cs
@@ -17,7 +17,8 @@ namespace Tests.UnitTests.ServiceTests
         [TestMethod]
         public void TestCreateWaspiCapture()
         {
-            var output = wasapiService.CreateWasapiCapture();
+            CancellationToken token = new();
+            var output = wasapiService.CreateWasapiCapture(token);
 
             Assert.IsNotNull(output);
             Assert.IsInstanceOfType(output, typeof(WasapiCaptureWrapper));
@@ -29,7 +30,8 @@ namespace Tests.UnitTests.ServiceTests
         [TestMethod]
         public void TestCreateWaspiOut()
         {
-            var output = wasapiService.CreateWasapiOut();
+            CancellationToken token = new();
+            var output = wasapiService.CreateWasapiOut(token);
 
             Assert.IsNotNull(output);
             Assert.IsInstanceOfType(output, typeof(WasapiOutWrapper));


### PR DESCRIPTION
Implements a CancellationToken check for WasapiCaptureWrapper and WasapiOutWrapper, which prevents errors when rapidly calling async start/stop methods.

Updates tests accordingly.