### PR TITLE
Mouse keybinds

### DIFF
--- a/TAC_COM/Models/Interfaces/IKeybind.cs
+++ b/TAC_COM/Models/Interfaces/IKeybind.cs
@@ -1,5 +1,6 @@
 ﻿using Dapplo.Windows.Input.Enums;
 using Dapplo.Windows.Input.Keyboard;
+using TAC_COM.Utilities.MouseHook;
 
 namespace TAC_COM.Models.Interfaces
 {
@@ -46,12 +47,20 @@ namespace TAC_COM.Models.Interfaces
         bool Shift { get; set; }
 
         /// <summary>
-        /// Method to determine if the keybind is currently pressed.
+        /// Method to determine if the keyboard keybind is currently pressed.
         /// </summary>
         /// <param name="args"> The <see cref="KeyboardHookEventArgs"/> to be
         /// checked against.</param>
         /// <returns> A boolean representing if the keybind is currently pressed.</returns>
         bool IsPressed(KeyboardHookEventArgs args);
+
+        /// <summary>
+        /// Method to determine if the mouse keybind is currently pressed.
+        /// </summary>
+        /// <param name="args"> The <see cref="MouseHookEventArgsExtended"/> to
+        /// be checked against.</param>
+        /// <returns> A boolean representing if the keybind is currently pressed.</returns>
+        bool IsPressed(MouseHookEventArgsExtended args);
 
         /// <summary>
         /// Method to determine if the keybind has been released.
@@ -61,6 +70,15 @@ namespace TAC_COM.Models.Interfaces
         /// <returns> A boolean representing if the keybind has been
         /// released.</returns>
         bool IsReleased(KeyboardHookEventArgs args);
+
+        /// <summary>
+        /// Method to determine if the mouse keybind has been released.
+        /// </summary>
+        /// <param name="args"> The <see cref="KeyboardHookEventArgs"/> to be
+        /// checked against.</param>
+        /// <returns> A boolean representing if the keybind has been
+        /// released.</returns>
+        bool IsReleased(MouseHookEventArgsExtended args);
 
         /// <summary>
         /// Method to manually call KeyUp combination,

--- a/TAC_COM/Models/Keybind.cs
+++ b/TAC_COM/Models/Keybind.cs
@@ -2,6 +2,7 @@
 using Dapplo.Windows.Input.Enums;
 using Dapplo.Windows.Input.Keyboard;
 using TAC_COM.Models.Interfaces;
+using TAC_COM.Utilities.MouseHook;
 
 namespace TAC_COM.Models
 {
@@ -107,7 +108,32 @@ namespace TAC_COM.Models
             else return false;
         }
 
+        public bool IsPressed(MouseHookEventArgsExtended args)
+        {
+            if (args.Key != KeyCode) return false;
+
+            args.Handled = !Passthrough;
+            
+            if (args.IsKeyDown)
+            {
+                return true;
+            }
+            else return false;
+        }
+
         public bool IsReleased(KeyboardHookEventArgs args)
+        {
+            if (args.Key == KeyCode)
+            {
+                if (!args.IsKeyDown)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public bool IsReleased(MouseHookEventArgsExtended args)
         {
             if (args.Key == KeyCode)
             {

--- a/TAC_COM/Models/KeybindManager.cs
+++ b/TAC_COM/Models/KeybindManager.cs
@@ -1,8 +1,10 @@
-﻿using Dapplo.Windows.Input.Enums;
+﻿using System.Reactive.Linq;
+using Dapplo.Windows.Input.Enums;
 using Dapplo.Windows.Input.Keyboard;
 using TAC_COM.Models.Interfaces;
 using TAC_COM.Services.Interfaces;
 using TAC_COM.Utilities;
+using TAC_COM.Utilities.MouseHook;
 
 namespace TAC_COM.Models
 {
@@ -19,6 +21,19 @@ namespace TAC_COM.Models
         private IDisposable? pttKeybindCatchSubscription;
         private IDisposable? userKeybindSubscription;
         private IDisposable? systemKeybindSubscription;
+
+        private IDisposable? pttMouseButtonSubscription;
+        private IDisposable? userMouseButtonSubscription;
+
+        private readonly HashSet<MouseMessages> allowedMouseMessages =
+        [
+            MouseMessages.WM_XBUTTON1DOWN,
+            MouseMessages.WM_XBUTTON1UP,
+            MouseMessages.WM_XBUTTON2DOWN,
+            MouseMessages.WM_XBUTTON2UP,
+            MouseMessages.WM_MBUTTONDOWN,
+            MouseMessages.WM_MBUTTONUP,
+        ];
 
         private ISettingsService settingsService = settingsService;
 
@@ -102,16 +117,32 @@ namespace TAC_COM.Models
             }
         }
 
+        public void TogglePTT(MouseHookEventArgsExtended args)
+        {
+            if (PTTKey != null)
+            {
+                if (PTTKey.IsPressed(args))
+                {
+                    if (!ToggleState) ToggleState = true;
+                }
+                if (PTTKey.IsReleased(args))
+                {
+                    if (ToggleState) ToggleState = false;
+                }
+            }
+        }
+
         public void TogglePTTKeybindSubscription(bool state)
         {
-            if (state) InitialisePTTKeySubscription();
+            if (state) InitialisePTTKeySubscriptions();
             else
             {
                 PTTKey?.CallKeyUp();
 
-                DisposeKeyboardSubscription(pttKeybindSubscription);
-                DisposeKeyboardSubscription(pttKeybindCatchSubscription);
-                DisposeKeyboardSubscription(systemKeybindSubscription);
+                pttKeybindSubscription?.Dispose();
+                pttKeybindCatchSubscription?.Dispose();
+                systemKeybindSubscription?.Dispose();
+                pttMouseButtonSubscription?.Dispose();
             };
         }
 
@@ -136,7 +167,7 @@ namespace TAC_COM.Models
         /// is handled here.
         /// </para>
         /// </remarks>
-        private void InitialisePTTKeySubscription()
+        private void InitialisePTTKeySubscriptions()
         {
             if (PTTKey == null) return;
 
@@ -173,18 +204,30 @@ namespace TAC_COM.Models
                 KeyboardInputGenerator.KeyUp(VirtualKeyCode.Control);
                 KeyboardInputGenerator.KeyUp(VirtualKeyCode.Menu);
             });
+
+            // Mouse hook to handle mouse button presses
+            pttMouseButtonSubscription
+                = MouseHookExtended.MouseEvents.Subscribe(args =>
+                {
+                    TogglePTT(args);
+                });
         }
 
         public void ToggleUserKeybindSubscription(bool state)
         {
             if (state) InitialiseUserKeybindSubscription();
-            else DisposeKeyboardSubscription(userKeybindSubscription);
+            else
+            {
+                userKeybindSubscription?.Dispose();
+                userMouseButtonSubscription?.Dispose();
+            }
         }
 
         /// <summary>
-        /// Method to initialise the <see cref="KeyboardHook"/> that
+        /// Method to initialise a <see cref="KeyboardHook"/> that
         /// listens for the user's proposed new keybind combination,
-        /// setting the <see cref="NewPTTKeybind"/> property.
+        /// as well as a <see cref="MouseHookExtended"/> that listens
+        /// for mouse button presses, updating the <see cref="NewPTTKeybind"/>.
         /// </summary>
         private void InitialiseUserKeybindSubscription()
         {
@@ -201,16 +244,17 @@ namespace TAC_COM.Models
                         NewPTTKeybind = new Keybind(args.Key, args.IsLeftShift, args.IsLeftControl, args.IsLeftAlt, args.IsModifier, PassthroughState);
                     }
                 });
-        }
 
-        /// <summary>
-        /// Method to manually dispose of an <see cref="IDisposable"/>
-        /// <see cref="KeyboardHook"/> subscription.
-        /// </summary>
-        /// <param name="subscription"></param>
-        private static void DisposeKeyboardSubscription(IDisposable? subscription)
-        {
-            subscription?.Dispose();
+            userMouseButtonSubscription = MouseHookExtended.MouseEvents.Subscribe(args =>
+            {
+                if (allowedMouseMessages.Contains(args.MouseMessage))
+                {
+                    if (args.IsKeyDown)
+                    {
+                        NewPTTKeybind = new Keybind(args.Key, false, false, false, false, PassthroughState);
+                    }
+                }
+            });
         }
 
         public void UpdateKeybind()
@@ -240,6 +284,8 @@ namespace TAC_COM.Models
             pttKeybindCatchSubscription?.Dispose();
             userKeybindSubscription?.Dispose();
             systemKeybindSubscription?.Dispose();
+            pttMouseButtonSubscription?.Dispose();
+            userMouseButtonSubscription?.Dispose();
         }
     }
 }

--- a/TAC_COM/Models/KeybindManager.cs
+++ b/TAC_COM/Models/KeybindManager.cs
@@ -107,8 +107,6 @@ namespace TAC_COM.Models
             if (state) InitialisePTTKeySubscription();
             else
             {
-                // Prevent hanging keybind if subscription ended
-                // whilst keybind still held.
                 PTTKey?.CallKeyUp();
 
                 DisposeKeyboardSubscription(pttKeybindSubscription);
@@ -190,6 +188,11 @@ namespace TAC_COM.Models
         /// </summary>
         private void InitialiseUserKeybindSubscription()
         {
+            if (PTTKey != null)
+            {
+                PTTKey?.CallKeyUp();
+            };
+
             userKeybindSubscription
                 = KeyboardHook.KeyboardEvents.Subscribe(args =>
                 {

--- a/TAC_COM/Models/KeybindManager.cs
+++ b/TAC_COM/Models/KeybindManager.cs
@@ -173,7 +173,7 @@ namespace TAC_COM.Models
 
             // Use generic keyboardEvents hook so that key up values are passed
             pttKeybindSubscription
-                = KeyboardHook.KeyboardEvents.Subscribe(args =>
+                = KeyboardHook.KeyboardEvents.Where(args => args.Key == PTTKey.KeyCode).Subscribe(args =>
                 {
                     TogglePTT(args);
                 });
@@ -207,7 +207,7 @@ namespace TAC_COM.Models
 
             // Mouse hook to handle mouse button presses
             pttMouseButtonSubscription
-                = MouseHookExtended.MouseEvents.Subscribe(args =>
+                = MouseHookExtended.MouseEvents.Where(args => allowedMouseMessages.Contains(args.MouseMessage)).Subscribe(args =>
                 {
                     TogglePTT(args);
                 });

--- a/TAC_COM/Models/KeybindManager.cs
+++ b/TAC_COM/Models/KeybindManager.cs
@@ -259,6 +259,8 @@ namespace TAC_COM.Models
 
         public void UpdateKeybind()
         {
+            ToggleUserKeybindSubscription(false);
+
             if (NewPTTKeybind != null) NewPTTKeybind.Passthrough = PassthroughState;
             PTTKey = NewPTTKeybind;
         }

--- a/TAC_COM/Utilities/MouseHook/MouseHookEventArgsExtended.cs
+++ b/TAC_COM/Utilities/MouseHook/MouseHookEventArgsExtended.cs
@@ -1,0 +1,39 @@
+﻿using Dapplo.Windows.Common.Structs;
+using Dapplo.Windows.Input.Enums;
+
+namespace TAC_COM.Utilities.MouseHook
+{
+    /// <summary>
+    /// Event arguments for the <see cref="MouseHookExtended"/> class.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the <see cref="Dapplo.Windows.Input.Mouse.MouseHookEventArgs"/>
+    /// </remarks>
+    public class MouseHookEventArgsExtended : EventArgs
+    {
+        /// <summary>
+        /// Set this to true if the event is handled, other event-handlers in the chain will not be called.
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <summary>
+        /// The x- and y-coordinates of the cursor, in per-monitor-aware screen coordinates.
+        /// </summary>
+        public NativePoint Point { get; set; }
+
+        /// <summary>
+        /// The mouse message.
+        /// </summary>
+        public MouseMessages MouseMessage { get; set; }
+
+        /// <summary>
+        /// The <see cref="VirtualKeyCode"/> of the mouse button.
+        /// </summary>
+        public VirtualKeyCode Key { get; set; }
+
+        /// <summary>
+        /// The state of the mouse button. If true, the button is down; otherwise, it is up.
+        /// </summary>
+        public bool IsKeyDown { get; set; }
+    }
+}

--- a/TAC_COM/Utilities/MouseHook/MouseHookExtended.cs
+++ b/TAC_COM/Utilities/MouseHook/MouseHookExtended.cs
@@ -1,0 +1,148 @@
+﻿using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Runtime.InteropServices;
+using Dapplo.Windows.Input.Enums;
+using Dapplo.Windows.Input.Structs;
+
+namespace TAC_COM.Utilities.MouseHook
+{
+    /// <summary>
+    /// Class to hook into the mouse events, extended to support
+    /// separate events for the XButton1, XButton2, as well as
+    /// utilising <see cref="VirtualKeyCode"/> alongside
+    /// <see cref="MouseMessages"/>.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the <see cref="Dapplo.Windows.Input.Mouse.MouseHook"/>
+    /// </remarks>
+    public class MouseHookExtended
+    {
+        /// <summary>
+        ///     The singleton of the MouseHook
+        /// </summary>
+        private static readonly Lazy<MouseHookExtended> Singleton = new(() => new MouseHookExtended());
+
+        /// <summary>
+        ///     Used to store the observable
+        /// </summary>
+        private readonly IObservable<MouseHookEventArgsExtended> _mouseObservable;
+
+        /// <summary>
+        ///     Store the handler, otherwise it might be GCed
+        /// </summary>
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+        private LowLevelMouseProc _callback;
+
+        /// <summary>
+        /// Private constructor to create the observable
+        /// </summary>
+        private MouseHookExtended()
+        {
+            _mouseObservable = Observable.Create<MouseHookEventArgsExtended>(observer =>
+            {
+                var hookId = nint.Zero;
+                // Need to hold onto this callback, otherwise it will get GC'd as it is an unmanaged callback
+                _callback = (nCode, wParam, lParam) =>
+                {
+                    if (nCode >= 0)
+                    {
+                        var eventArgs = CreateMouseEventArgs(wParam, lParam);
+                        observer.OnNext(eventArgs);
+                        if (eventArgs.Handled)
+                        {
+                            return 1;
+                        }
+                    }
+
+                    // ReSharper disable once AccessToModifiedClosure
+                    return CallNextHookEx(hookId, nCode, wParam, lParam);
+                };
+
+                hookId = SetWindowsHookEx(HookTypes.WH_MOUSE_LL, _callback, nint.Zero, 0);
+
+                return Disposable.Create(() =>
+                {
+                    UnhookWindowsHookEx(hookId);
+                    _callback = null;
+                });
+            })
+            .Publish()
+            .RefCount();
+        }
+
+        /// <summary>
+        ///     The actual keyboard hook observable
+        /// </summary>
+        public static IObservable<MouseHookEventArgsExtended> MouseEvents => Singleton.Value._mouseObservable;
+
+        /// <summary>
+        ///     Create the MouseEventArgs from the parameters which were in the event
+        /// </summary>
+        /// <param name="wParam">IntPtr</param>
+        /// <param name="lParam">IntPtr</param>
+        /// <returns>MouseEventArgs</returns>
+        private static MouseHookEventArgsExtended CreateMouseEventArgs(nint wParam, nint lParam)
+        {
+            var mouseLowLevelHookStruct = (MouseLowLevelHookStruct)Marshal.PtrToStructure(lParam, typeof(MouseLowLevelHookStruct));
+            var mouseMessage = (MouseMessages)wParam.ToInt32();
+            VirtualKeyCode keyCode = VirtualKeyCode.None;
+            bool isKeyDown = false;
+
+            // Handle XButton1 and XButton2
+            // Here, the XButton messages are split into separate messages for each button.
+            // The high-order word of MouseData specifies which X button was pressed or released.
+            if (mouseMessage == MouseMessages.WM_XBUTTON1DOWN 
+                || mouseMessage == MouseMessages.WM_XBUTTON1UP)
+            {
+                uint xButton = mouseLowLevelHookStruct.MouseData >> 16;
+                if (xButton == 1)
+                {
+                    mouseMessage = mouseMessage == MouseMessages.WM_XBUTTON1DOWN
+                        ? MouseMessages.WM_XBUTTON1DOWN
+                        : MouseMessages.WM_XBUTTON1UP;
+
+                    keyCode = VirtualKeyCode.Xbutton1;
+                    isKeyDown = mouseMessage == MouseMessages.WM_XBUTTON1DOWN;
+                }
+                else if (xButton == 2)
+                {
+                    mouseMessage = mouseMessage == MouseMessages.WM_XBUTTON1DOWN
+                        ? MouseMessages.WM_XBUTTON2DOWN
+                        : MouseMessages.WM_XBUTTON2UP;
+
+                    keyCode = VirtualKeyCode.Xbutton2;
+                    isKeyDown = mouseMessage == MouseMessages.WM_XBUTTON2DOWN;
+                }
+            }
+            // Handle middle mouse button
+            else if (mouseMessage == MouseMessages.WM_MBUTTONDOWN 
+                || mouseMessage == MouseMessages.WM_MBUTTONUP)
+            {
+                keyCode = VirtualKeyCode.Mbutton;
+                isKeyDown = mouseMessage == MouseMessages.WM_MBUTTONDOWN;
+            }
+
+            var mouseEventArgs = new MouseHookEventArgsExtended
+            {
+                MouseMessage = mouseMessage,
+                Point = mouseLowLevelHookStruct.pt,
+                Key = keyCode,
+                IsKeyDown = isKeyDown,
+            };
+
+            return mouseEventArgs;
+        }
+
+        private delegate nint LowLevelMouseProc(int nCode, nint wParam, nint lParam);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern nint SetWindowsHookEx(HookTypes hookType, LowLevelMouseProc lpfn, nint hMod, uint dwThreadId);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool UnhookWindowsHookEx(nint hhk);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern nint CallNextHookEx(nint hhk, int nCode, nint wParam, nint lParam);
+    }
+}

--- a/TAC_COM/Utilities/MouseHook/MouseMessages.cs
+++ b/TAC_COM/Utilities/MouseHook/MouseMessages.cs
@@ -1,0 +1,15 @@
+﻿namespace TAC_COM.Utilities.MouseHook
+{
+    /// <summary>
+    /// Enum to represent the Windows messages used in the <see cref="MouseHookExtended"/>.
+    /// </summary>
+    public enum MouseMessages : uint
+    {
+        WM_MBUTTONDOWN = 0x0207,
+        WM_MBUTTONUP = 0x0208,
+        WM_XBUTTON1DOWN = 0x020B,
+        WM_XBUTTON1UP = 0x020C,
+        WM_XBUTTON2DOWN = 0x020D,
+        WM_XBUTTON2UP = 0x020E,
+    }
+}

--- a/TAC_COM/ViewModels/KeybindWindowViewModel.cs
+++ b/TAC_COM/ViewModels/KeybindWindowViewModel.cs
@@ -82,7 +82,6 @@ namespace TAC_COM.ViewModels
         /// </summary>
         private void ExecuteCloseKeybindDialog()
         {
-            KeybindManager.ToggleUserKeybindSubscription(false);
             KeybindManager.UpdateKeybind();
             RaiseClose();
         }

--- a/Tests/UnitTests/ModelTests/KeybindTests.cs
+++ b/Tests/UnitTests/ModelTests/KeybindTests.cs
@@ -173,7 +173,7 @@ namespace Tests.UnitTests.ModelTests
         /// method.
         /// </summary>
         [TestMethod]
-        public void TestIsReleased()
+        public void TestIsReleased_Keyboard()
         {
             testKeybind = new Keybind(
                 keyCode: VirtualKeyCode.KeyF,
@@ -202,13 +202,40 @@ namespace Tests.UnitTests.ModelTests
 
             KeyboardInputGenerator.KeyUp(VirtualKeyCode.KeyF);
 
-            Assert.IsTrue(keyboardCorrectTestArgs != null);
+            Assert.IsNotNull(keyboardCorrectTestArgs);
             Assert.IsTrue(testKeybind.IsReleased(keyboardCorrectTestArgs));
 
             KeyboardInputGenerator.KeyDown(VirtualKeyCode.KeyF);
 
-            Assert.IsTrue(keyboardIncorrectTestArgs != null);
+            Assert.IsNotNull(keyboardIncorrectTestArgs);
             Assert.IsFalse(testKeybind.IsReleased(keyboardIncorrectTestArgs));
+        }
+
+        [TestMethod]
+        public void TestIsReleased_Mouse()
+        {
+            testKeybind = new Keybind(
+                keyCode: VirtualKeyCode.Mbutton,
+                shift: false,
+                ctrl: false,
+                alt: false,
+                isModifier: false,
+                passthrough: false);
+
+            var testCorrectArgs = new MouseHookEventArgsExtended
+            {
+                Key = VirtualKeyCode.Mbutton,
+                IsKeyDown = false
+            };
+
+            var testIncorrectArgs = new MouseHookEventArgsExtended
+            {
+                Key = VirtualKeyCode.Xbutton1,
+                IsKeyDown = false
+            };
+
+            Assert.IsTrue(testKeybind.IsReleased(testCorrectArgs));
+            Assert.IsFalse(testKeybind.IsReleased(testIncorrectArgs));
         }
 
         /// <summary>

--- a/Tests/UnitTests/ModelTests/KeybindTests.cs
+++ b/Tests/UnitTests/ModelTests/KeybindTests.cs
@@ -211,6 +211,9 @@ namespace Tests.UnitTests.ModelTests
             Assert.IsFalse(testKeybind.IsReleased(keyboardIncorrectTestArgs));
         }
 
+        /// <summary>
+        /// Test method for the <see cref="Keybind.IsReleased(MouseHookEventArgsExtended)"/>
+        /// </summary>
         [TestMethod]
         public void TestIsReleased_Mouse()
         {
@@ -283,7 +286,7 @@ namespace Tests.UnitTests.ModelTests
 
             var expectedString = "Shift + Ctrl + Alt + V";
 
-            Assert.AreEqual(testKeybind.ToString(), expectedString);
+            Assert.AreEqual(expectedString, testKeybind.ToString());
         }
 
         /// <summary>

--- a/Tests/UnitTests/ModelTests/KeybindTests.cs
+++ b/Tests/UnitTests/ModelTests/KeybindTests.cs
@@ -1,6 +1,8 @@
 ﻿using Dapplo.Windows.Input.Enums;
 using Dapplo.Windows.Input.Keyboard;
+using Dapplo.Windows.Input.Mouse;
 using TAC_COM.Models;
+using TAC_COM.Utilities.MouseHook;
 
 namespace Tests.UnitTests.ModelTests
 {
@@ -97,7 +99,7 @@ namespace Tests.UnitTests.ModelTests
         /// method.
         /// </summary>
         [TestMethod]
-        public void TestIsPressed()
+        public void TestIsPressed_Keyboard()
         {
             testKeybind = new Keybind(
                 keyCode: VirtualKeyCode.KeyV,
@@ -129,13 +131,57 @@ namespace Tests.UnitTests.ModelTests
 
             KeyboardInputGenerator.KeyCombinationPress([VirtualKeyCode.Shift, VirtualKeyCode.KeyV]);
 
-            Assert.IsTrue(keyboardCorrectTestArgs != null);
+            Assert.IsNotNull(keyboardCorrectTestArgs);
             Assert.IsTrue(testKeybind.IsPressed(keyboardCorrectTestArgs));
 
             KeyboardInputGenerator.KeyCombinationPress([VirtualKeyCode.Control, VirtualKeyCode.KeyX]);
 
-            Assert.IsTrue(keyboardIncorrectTestArgs != null);
+            Assert.IsNotNull(keyboardIncorrectTestArgs);
             Assert.IsFalse(testKeybind.IsPressed(keyboardIncorrectTestArgs));
+        }
+
+        [TestMethod]
+        public void TestIsPressed_Mouse()
+        {
+            testKeybind = new Keybind(
+                keyCode: VirtualKeyCode.Mbutton,
+                shift: false,
+                ctrl: false,
+                alt: false,
+                isModifier: false,
+                passthrough: false);
+
+            MouseHookEventArgsExtended? mouseCorrectTestArgs = null;
+
+            var testCorrectSubscription = MouseHookExtended.MouseEvents.Subscribe(args =>
+            {
+                if (args.Key == testKeybind.KeyCode)
+                {
+                    mouseCorrectTestArgs = args;
+                }
+            });
+
+            MouseHookEventArgsExtended? mouseIncorrectTestArgs = null;
+
+            VirtualKeyCode incorrectKeyCode = VirtualKeyCode.Xbutton1;
+
+            var testIncorrectSubscription = MouseHookExtended.MouseEvents.Subscribe(args =>
+            {
+                if (args.Key == incorrectKeyCode)
+                {
+                    mouseIncorrectTestArgs = args;
+                }
+            });
+
+            MouseInputGenerator.MouseDown(MouseButtons.Middle);
+
+            Assert.IsNotNull(mouseCorrectTestArgs);
+            Assert.IsTrue(testKeybind.IsPressed(mouseCorrectTestArgs));
+
+            MouseInputGenerator.MouseDown(MouseButtons.XButton1);
+
+            Assert.IsNotNull(mouseIncorrectTestArgs);
+            Assert.IsFalse(testKeybind.IsPressed(mouseIncorrectTestArgs));
         }
 
         /// <summary>

--- a/Tests/UnitTests/ModelTests/KeybindTests.cs
+++ b/Tests/UnitTests/ModelTests/KeybindTests.cs
@@ -1,4 +1,5 @@
-﻿using Dapplo.Windows.Input.Enums;
+﻿using System.Reactive.Linq;
+using Dapplo.Windows.Input.Enums;
 using Dapplo.Windows.Input.Keyboard;
 using Dapplo.Windows.Input.Mouse;
 using TAC_COM.Models;
@@ -151,37 +152,20 @@ namespace Tests.UnitTests.ModelTests
                 isModifier: false,
                 passthrough: false);
 
-            MouseHookEventArgsExtended? mouseCorrectTestArgs = null;
-
-            var testCorrectSubscription = MouseHookExtended.MouseEvents.Subscribe(args =>
+            var testCorrectArgs = new MouseHookEventArgsExtended
             {
-                if (args.Key == testKeybind.KeyCode)
-                {
-                    mouseCorrectTestArgs = args;
-                }
-            });
+                Key = VirtualKeyCode.Mbutton,
+                IsKeyDown = true
+            };
 
-            MouseHookEventArgsExtended? mouseIncorrectTestArgs = null;
-
-            VirtualKeyCode incorrectKeyCode = VirtualKeyCode.Xbutton1;
-
-            var testIncorrectSubscription = MouseHookExtended.MouseEvents.Subscribe(args =>
+            var testIncorrectArgs = new MouseHookEventArgsExtended
             {
-                if (args.Key == incorrectKeyCode)
-                {
-                    mouseIncorrectTestArgs = args;
-                }
-            });
+                Key = VirtualKeyCode.Xbutton1,
+                IsKeyDown = true
+            };
 
-            MouseInputGenerator.MouseDown(MouseButtons.Middle);
-
-            Assert.IsNotNull(mouseCorrectTestArgs);
-            Assert.IsTrue(testKeybind.IsPressed(mouseCorrectTestArgs));
-
-            MouseInputGenerator.MouseDown(MouseButtons.XButton1);
-
-            Assert.IsNotNull(mouseIncorrectTestArgs);
-            Assert.IsFalse(testKeybind.IsPressed(mouseIncorrectTestArgs));
+            Assert.IsTrue(testKeybind.IsPressed(testCorrectArgs));
+            Assert.IsFalse(testKeybind.IsPressed(testIncorrectArgs));
         }
 
         /// <summary>

--- a/Tests/UnitTests/ViewModelTests/KeybindWindowViewModelTests.cs
+++ b/Tests/UnitTests/ViewModelTests/KeybindWindowViewModelTests.cs
@@ -57,7 +57,7 @@ namespace Tests.UnitTests.ViewModelTests
         public void TestNewKeybindNameProperty()
         {
             Utils.TestPropertyChange(testViewModel, nameof(testViewModel.NewKeybindName), "Shift + V");
-            Assert.IsTrue(testViewModel.NewKeybindName == "[ Shift + V ]");
+            Assert.AreEqual("[ Shift + V ]", testViewModel.NewKeybindName);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Tests.UnitTests.ViewModelTests
             testViewModel.KeybindManager = mockKeybindManager.Object;
 
             Utils.TestPropertyChange(testViewModel, nameof(testViewModel.PassthroughState), true);
-            Assert.IsTrue(testViewModel.PassthroughState == true);
+            Assert.AreEqual(true, testViewModel.PassthroughState);
             mockKeybindManager.VerifySet(keybindManager => keybindManager.PassthroughState = true);
         }
 
@@ -83,7 +83,6 @@ namespace Tests.UnitTests.ViewModelTests
         public void TestExecuteCloseKeybindDialogCommand()
         {
             var mockKeybindManager = new Mock<IKeybindManager>();
-            mockKeybindManager.Setup(keybindManager => keybindManager.ToggleUserKeybindSubscription(false)).Verifiable();
             mockKeybindManager.Setup(keybindManager => keybindManager.UpdateKeybind()).Verifiable();
 
             testViewModel.KeybindManager = mockKeybindManager.Object;
@@ -92,7 +91,7 @@ namespace Tests.UnitTests.ViewModelTests
             testViewModel.Close += (sender, e) => closeEventRaised = true;
 
             testViewModel.CloseKeybindDialog.Execute(null);
-            mockKeybindManager.Verify(keybindManager => keybindManager.ToggleUserKeybindSubscription(false), Times.Once);
+
             mockKeybindManager.Verify(keybindManager => keybindManager.UpdateKeybind(), Times.Once);
             Assert.IsTrue(closeEventRaised, "The Close event was not raised.");
         }

--- a/Tests/UnitTests/ViewModelTests/KeybindWindowViewModelTests.cs
+++ b/Tests/UnitTests/ViewModelTests/KeybindWindowViewModelTests.cs
@@ -72,7 +72,7 @@ namespace Tests.UnitTests.ViewModelTests
             testViewModel.KeybindManager = mockKeybindManager.Object;
 
             Utils.TestPropertyChange(testViewModel, nameof(testViewModel.PassthroughState), true);
-            Assert.AreEqual(true, testViewModel.PassthroughState);
+            Assert.IsTrue(testViewModel.PassthroughState);
             mockKeybindManager.VerifySet(keybindManager => keybindManager.PassthroughState = true);
         }
 


### PR DESCRIPTION
Adds the ability to bind the PTT key to Middle Mouse (MB3), Mouse 4 (XButton1) and Mouse 5 (XButton2). Updates tests accordingly.

Also fixes a potential crash when toggle PTT extremely rapidly.